### PR TITLE
merging changes from Keegan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: dmrseq
 Type: Package
 Title: Detection and inference of differentially methylated regions 
   from Whole Genome Bisulfite Sequencing 
-Version: 0.99.12
+Version: 0.99.13
 Author: Keegan Korthauer <keegan@jimmy.harvard.edu>, 
   Sutirtha Chakraborty <statistuta@gmail.com>, 
   Yuval Benjamini <yuvalbenj@gmail.com>, 

--- a/R/dmrseq.R
+++ b/R/dmrseq.R
@@ -613,6 +613,17 @@ dmrseq <- function(bs, testCovariate, adjustCovariate = NULL, cutoff = 0.1,
     }
     
     # convert output into GRanges, with indexStart/indexEnd as IRanges
+    # convert index from within chromosome to overall
+    chrlengths <- cumsum(table(seqnames(bs)))
+    chrs <- unique(as.character(seqnames(bs)))
+    for (j in seq_len(length(chrs)-1)) {
+      ch <- chrs[j+1]
+      OBS$indexStart[OBS$chr == ch] <- OBS$indexStart[OBS$chr == ch] +
+        chrlengths[names(chrlengths) == chrs[j]] 
+      OBS$indexEnd[OBS$chr == ch] <- OBS$indexEnd[OBS$chr == ch] +
+        chrlengths[names(chrlengths) == chrs[j]] 
+    }
+    
     indexIR <- IRanges(OBS$indexStart, OBS$indexEnd)
     OBS.gr <- makeGRangesFromDataFrame(OBS[,-c(4:5)], 
                                        keep.extra.columns = TRUE)


### PR DESCRIPTION
Previously indexes were with respect to each chromosome. This commit
fixes this bug by making indexes relative to the elements of the
original BSseq object.